### PR TITLE
decrease symbol definition verbosity for java.lang members

### DIFF
--- a/src/language/structs.ts
+++ b/src/language/structs.ts
@@ -49,7 +49,7 @@ export class ReferenceType extends Type {
     }
 
     toString(): string {
-        return this.raw.slice(1, -1).replace(/\//g, '.');
+        return this.raw.slice(1, -1).replace(/\//g, '.').replace('java.lang.', '');
     }
 
     get identifier(): string | undefined { return this.raw; }


### PR DESCRIPTION
It makes cross-references from Java source easier as most dex->java decompilers don't produce full type for `java.lang` package members for their familiarity.